### PR TITLE
Node version for semantic-release needs to be at least 20.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: "lts/*"
       - name: Install dependencies
         run: npm ci
       - name: Release


### PR DESCRIPTION
Received this error message when the release workflow ran.

```
[semantic-release]: node version >=20.8.1 is required. Found v18.20.1.
See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md for more details and solutions.
```
