### PR TITLE
Received error when trying to run workflow release for branch.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
       - alpha
+      - develop/nutmeg.master
+      - develop/maple.3
   release:
     types: [created]
 


### PR DESCRIPTION
Error
```
[3:13:35 PM] [semantic-release] › ℹ  This test run was triggered on the branch refs/tags/2.1.2-nutmeg.2.1, while semantic-release is configured to only publish from master, alpha, therefore a new version won’t be published.
```
