### PR TITLE
Be able to run `semantic-release` on develop branches.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,20 @@ on:
     branches:
       - master
       - alpha
-      - develop/nutmeg.master
-      - develop/maple.3
-  release:
-    types: [created]
+      - develop/**
+
+permissions:
+  contents: read # for checkout
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Example for `semantic-release` for Github Actions.
https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md
