### PR TITLE
Make sure the `semantic-release` adheres to specific branches.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - alpha
-      - develop/**
 
 permissions:
   contents: read # for checkout


### PR DESCRIPTION
Error:
```
[3:47:28 PM] [semantic-release] › ℹ  This test run was triggered on the branch develop/nutmeg.master, while semantic-release is configured to only publish from master, alpha, therefore a new version won’t be published.
```

Looks like `semantic-release` has specific branches that it uses to release from.
https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches
